### PR TITLE
src: Update glyphs.h includes so that they don't use relatives includes

### DIFF
--- a/src/commands/attestinput/ainpt_ui.c
+++ b/src/commands/attestinput/ainpt_ui.c
@@ -1,9 +1,10 @@
 #include <os.h>
 #include <ux.h>
 
+#include "glyphs.h"
+
 #include "ainpt_ui.h"
 #include "ainpt_response.h"
-#include "../../glyphs.h"
 #include "../../globals.h"
 #include "../../common/macros.h"
 #include "../../helpers/response.h"

--- a/src/commands/deriveaddress/da_ui.c
+++ b/src/commands/deriveaddress/da_ui.c
@@ -1,11 +1,12 @@
 #include <os.h>
 #include <ux.h>
 
+#include "glyphs.h"
+
 #include "da_ui.h"
 #include "da_response.h"
 #include "da_context.h"
 #include "../../sw.h"
-#include "../../glyphs.h"
 #include "../../globals.h"
 #include "../../context.h"
 #include "../../common/base58.h"

--- a/src/commands/extpubkey/epk_ui.c
+++ b/src/commands/extpubkey/epk_ui.c
@@ -2,9 +2,10 @@
 #include <ux.h>
 #include <string.h>
 
+#include "glyphs.h"
+
 #include "epk_ui.h"
 #include "epk_response.h"
-#include "../../glyphs.h"
 #include "../../globals.h"
 #include "../../context.h"
 #include "../../sw.h"

--- a/src/commands/signtx/stx_ui.c
+++ b/src/commands/signtx/stx_ui.c
@@ -1,9 +1,10 @@
 #include <os.h>
 #include <ux.h>
 
+#include "glyphs.h"
+
 #include "stx_ui.h"
 #include "stx_response.h"
-#include "../../glyphs.h"
 #include "../../globals.h"
 #include "../../common/macros.h"
 #include "../../helpers/response.h"

--- a/src/ui/ui_approve_reject.c
+++ b/src/ui/ui_approve_reject.c
@@ -1,5 +1,6 @@
+#include "glyphs.h"
+
 #include "ui_approve_reject.h"
-#include "../glyphs.h"
 
 static ui_approve_reject_callback G_ui_approve_reject_callback;
 static void* G_ui_approve_reject_callback_context;

--- a/src/ui/ui_menu.c
+++ b/src/ui/ui_menu.c
@@ -17,7 +17,8 @@
 
 #include <os.h>
 #include <ux.h>
-#include "../glyphs.h"
+
+#include "glyphs.h"
 
 #include "../globals.h"
 #include "ui_menu.h"


### PR DESCRIPTION
This is necessary as this file is automatically generated and it's generation location is going to change